### PR TITLE
Fix pipectl command and deployment status display

### DIFF
--- a/pkg/pipectl/cmd.go
+++ b/pkg/pipectl/cmd.go
@@ -38,8 +38,9 @@ type pipectl struct {
 func NewCommand() *cobra.Command {
 	c := pipectl{
 		statuses: []string{
-			model.DeploymentStatus_DEPLOYMENT_PENDING.String(),
+			// model.DeploymentStatus_DEPLOYMENT_PENDING.String(),
 			model.DeploymentStatus_DEPLOYMENT_RUNNING.String(),
+			// model.DeploymentStatus_DEPLOYMENT_SUCCESS.String(),
 		},
 		limit:  50,
 		stdout: os.Stdout,

--- a/pkg/pipectl/deployment.go
+++ b/pkg/pipectl/deployment.go
@@ -60,13 +60,17 @@ func (c *pipectl) listDeployments(ctx context.Context) error {
 					},
 				},
 			},
-			xbar.Xbar{
-				Line: xbar.Line{
-					Title: makeStageStatus(d.Stages),
-				},
-			},
-			xbar.SeparateLine,
 		)
+
+		if stageStatus, ok := makeStageStatus(d.Stages); ok {
+			xbars = append(xbars,
+				xbar.Xbar{
+					Line: xbar.Line{
+						Title: stageStatus,
+					}},
+			)
+		}
+		xbars = append(xbars, xbar.SeparateLine)
 
 		switch d.Status {
 		case model.DeploymentStatus_DEPLOYMENT_PENDING:
@@ -83,6 +87,7 @@ func (c *pipectl) listDeployments(ctx context.Context) error {
 				TemplateImage: &pipecdIconBase64,
 			},
 		},
+		xbar.SeparateLine,
 	}, xbars...)
 
 	for _, x := range xbars {
@@ -115,7 +120,7 @@ func makeStatusIcon(deployment *model.Deployment) string {
 	}
 }
 
-func makeStageStatus(stages []*model.PipelineStage) string {
+func makeStageStatus(stages []*model.PipelineStage) (string, bool) {
 	var runningStage string
 	for _, stage := range stages {
 		if stage.Status == model.StageStatus_STAGE_RUNNING {
@@ -123,7 +128,11 @@ func makeStageStatus(stages []*model.PipelineStage) string {
 		}
 	}
 
-	return fmt.Sprintf("%s %s", makeStageStatusIcon(runningStage), runningStage)
+	if runningStage == "" {
+		return "", false
+	}
+
+	return fmt.Sprintf("%s %s", makeStageStatusIcon(runningStage), runningStage), true
 }
 
 // TODO: Add icon for each stage.


### PR DESCRIPTION
This pull request primarily involves changes to the `pipectl` struct and its associated functions in the `pkg/pipectl/cmd.go` and `pkg/pipectl/deployment.go` files. The most significant changes include commenting out certain deployment statuses, modifying the `listDeployments` function to conditionally append `xbars`, and changing the `makeStageStatus` function to return a boolean value along with the stage status.

Here are the key changes in detail:

Changes to `pipectl` struct:

* [`pkg/pipectl/cmd.go`](diffhunk://#diff-9e1ae351b7c2297359e825724562f52889ac57c5e97c725eda721e5b0ee9bb17L41-R43): Commented out `model.DeploymentStatus_DEPLOYMENT_PENDING.String()` and `model.DeploymentStatus_DEPLOYMENT_SUCCESS.String()` in the `statuses` slice of the `pipectl` struct. This suggests that these deployment statuses are no longer in use.

Changes to `listDeployments` function:

* [`pkg/pipectl/deployment.go`](diffhunk://#diff-9297a6f01c94c5924e688b2410447546c76daa24bda202d87fc287ebca4dfe00R63-R73): Modified the `listDeployments` function to conditionally append `xbars` based on the result of `makeStageStatus`. This change introduces a more efficient way of handling the `xbars` appending process.
* [`pkg/pipectl/deployment.go`](diffhunk://#diff-9297a6f01c94c5924e688b2410447546c76daa24bda202d87fc287ebca4dfe00R90): Added `xbar.SeparateLine` after the `xbars` slice in the `listDeployments` function. This ensures a separate line is added after each xbar.

Changes to `makeStageStatus` function:

* [`pkg/pipectl/deployment.go`](diffhunk://#diff-9297a6f01c94c5924e688b2410447546c76daa24bda202d87fc287ebca4dfe00L118-R135): Changed the `makeStageStatus` function to return a boolean value along with the stage status. This allows the function to indicate whether a running stage was found.