### PR TITLE
Add icons for each stage in makeStageStatusIcon function

### DIFF
--- a/pkg/pipectl/deployment.go
+++ b/pkg/pipectl/deployment.go
@@ -13,6 +13,9 @@ import (
 	"github.com/BIwashi/xpipecd-xbar/pkg/xbar"
 )
 
+//go:embed pipecd_base64.txt
+var pipecdIconBase64 string
+
 func (c *pipectl) listDeployments(ctx context.Context) error {
 	labels := map[string]string{}
 	for _, label := range c.labels {
@@ -43,7 +46,10 @@ func (c *pipectl) listDeployments(ctx context.Context) error {
 	)
 
 	for _, d := range resp.Deployments {
-		l := c.makeDeploymentLink(d)
+		var (
+			l  = c.makeDeploymentLink(d)
+			tr = true
+		)
 
 		xbars = append(xbars,
 			xbar.Xbar{
@@ -67,9 +73,11 @@ func (c *pipectl) listDeployments(ctx context.Context) error {
 				xbar.Xbar{
 					Line: xbar.Line{
 						Title: stageStatus,
-					}},
+					},
+				},
 			)
 		}
+
 		xbars = append(xbars, xbar.SeparateLine)
 
 		switch d.Status {
@@ -101,20 +109,35 @@ func (c *pipectl) makeDeploymentLink(deployment *model.Deployment) string {
 	return fmt.Sprintf("https://%s/deployments/%s/", c.host, deployment.Id)
 }
 
+const (
+	iconHeavyExclamationMark   = ":heavy_exclamation_mark:"  // ❗
+	iconArrowsCounterclockwise = ":arrows_counterclockwise:" // 🔄
+	iconArrowForward           = ":arrow_forward:"           // ▶️
+	iconRewind                 = ":rewind:"                  // ⏪
+	iconWhiteCheckMark         = ":white_check_mark:"        // ✅
+	iconX                      = ":x:"                       // ❌
+	iconNoEntry                = ":no_entry:"                // ⛔
+	iconHourglassFlowingSand   = ":hourglass_flowing_sand:"  // ⏳
+	iconCloud                  = ":cloud:"                   // ☁️
+	iconMag                    = ":mag:"                     // 🔍
+	iconBabyChick              = ":baby_chick:"              // 🐤
+	iconHand                   = ":hand:"                    // ✋
+)
+
 func makeStatusIcon(deployment *model.Deployment) string {
 	switch deployment.Status {
 	case model.DeploymentStatus_DEPLOYMENT_PENDING:
-		return ":heavy_exclamation_mark:"
+		return iconHeavyExclamationMark
 	case model.DeploymentStatus_DEPLOYMENT_RUNNING:
-		return ":arrows_counterclockwise:"
+		return iconArrowsCounterclockwise
 	case model.DeploymentStatus_DEPLOYMENT_ROLLING_BACK:
-		return ":rewind:"
+		return iconRewind
 	case model.DeploymentStatus_DEPLOYMENT_SUCCESS:
-		return ":white_check_mark:"
+		return iconWhiteCheckMark
 	case model.DeploymentStatus_DEPLOYMENT_FAILURE:
-		return ":x:"
+		return iconX
 	case model.DeploymentStatus_DEPLOYMENT_CANCELLED:
-		return ":no_entry:"
+		return iconNoEntry
 	default:
 		return ""
 	}
@@ -135,44 +158,35 @@ func makeStageStatus(stages []*model.PipelineStage) (string, bool) {
 	return fmt.Sprintf("%s %s", makeStageStatusIcon(runningStage), runningStage), true
 }
 
-// TODO: Add icon for each stage.
 func makeStageStatusIcon(runningStage string) string {
 	switch runningStage {
 	case string(model.StageWait):
-		return ""
+		return iconHourglassFlowingSand
 	case string(model.StageWaitApproval):
-		return ":hand:"
+		return iconHand
 	case string(model.StageAnalysis):
-		return ""
+		return iconMag
 	case string(model.StageTerraformSync):
-		return ":cloud:"
+		return iconArrowsCounterclockwise
 	case string(model.StageTerraformPlan):
-		return ":cloud:"
+		return iconArrowForward
 	case string(model.StageTerraformApply):
-		return ":cloud:"
+		return iconArrowForward
 	case string(model.StageECSSync):
-		return ":cloud:"
+		return iconArrowsCounterclockwise
 	case string(model.StageECSCanaryRollout):
-		return ":cloud:"
+		return iconBabyChick
 	case string(model.StageECSTrafficRouting):
-		return ":cloud:"
+		return iconBabyChick
 	case string(model.StageECSCanaryClean):
-		return ":cloud:"
+		return iconBabyChick
 	case string(model.StageCustomSync):
-		return ":cloud:"
+		return iconArrowsCounterclockwise
 	case string(model.StageRollback):
-		return ":rewind:"
+		return iconRewind
 	case string(model.StageCustomSyncRollback):
-		return ":rewind:"
+		return iconArrowsCounterclockwise
 	default:
 		return ""
 	}
 }
-
-//go:embed pipecd_base64.txt
-var pipecdIconBase64 string
-
-var (
-	tr = true  //nolint:unused
-	fl = false //nolint:unused
-)


### PR DESCRIPTION
This pull request introduces several changes to the `pkg/pipectl/deployment.go` file. The changes primarily focus on improving code readability and maintainability, and include the addition of a new variable `pipecdIconBase64`, the replacement of hard-coded icon strings with constants, and modifications to the `listDeployments` and `makeStageStatusIcon` functions.

Here are the most important changes:

**Code Readability Improvements:**

* [`pkg/pipectl/deployment.go`](diffhunk://#diff-9297a6f01c94c5924e688b2410447546c76daa24bda202d87fc287ebca4dfe00R112-R140): Introduced a set of constants for various icon strings, replacing the hard-coded strings in the `makeStatusIcon` and `makeStageStatusIcon` functions. This change improves code readability and maintainability as it reduces the risk of typos and makes it easier to update or add new icons in the future. [[1]](diffhunk://#diff-9297a6f01c94c5924e688b2410447546c76daa24bda202d87fc287ebca4dfe00R112-R140) [[2]](diffhunk://#diff-9297a6f01c94c5924e688b2410447546c76daa24bda202d87fc287ebca4dfe00L138-L178)

**Function Modifications:**

* [`pkg/pipectl/deployment.go`](diffhunk://#diff-9297a6f01c94c5924e688b2410447546c76daa24bda202d87fc287ebca4dfe00L46-R52): In the `listDeployments` function, the code was refactored to declare variables `l` and `tr` using a var block. This change improves code readability.
* [`pkg/pipectl/deployment.go`](diffhunk://#diff-9297a6f01c94c5924e688b2410447546c76daa24bda202d87fc287ebca4dfe00L138-L178): The `makeStageStatusIcon` function was updated to return specific icons for each stage, replacing the previous placeholders and empty strings. This change enhances the user experience by providing more informative visual cues.

**New Variable Addition:**

* [`pkg/pipecl/deployment.go`](diffhunk://#diff-9297a6f01c94c5924e688b2410447546c76daa24bda202d87fc287ebca4dfe00R16-R18): Added a new variable `pipecdIconBase64` at the top of the file. This variable is declared using the `go:embed` directive, which allows it to be initialized with the content of the `pipecd_base64.txt` file at compile time.