### PR TITLE
Add GitHub release workflow and release configuration file

### DIFF
--- a/.github/workflows/gh-release.yaml
+++ b/.github/workflows/gh-release.yaml
@@ -1,0 +1,53 @@
+name: gh-release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "**/RELEASE"
+  workflow_dispatch:
+
+jobs:
+  gh-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: pipe-cd/actions-gh-release@v2.6.0
+        with:
+          release_file: "**/RELEASE"
+          token: ${{ secrets.GITHUB_TOKEN }}
+  upload-artifacts:
+    needs: gh-release
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os-arch:
+          - { os: "darwin", arch: "amd64" }
+          - { os: "darwin", arch: "arm64" }
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Build CLI for ${{ matrix.os-arch.os }}/${{ matrix.os-arch.arch }}
+        run: make build/cli BUILD_OS=${{ matrix.os-arch.os }} BUILD_ARCH=${{ matrix.os-arch.arch }}
+      - name: Create ZIP Archive for ${{ matrix.os-arch.os }}/${{ matrix.os-arch.arch }}
+        run: zip -r xpipecd-xbar-${{ github.sha }}-${{ matrix.os-arch.os }}-${{ matrix.os-arch.arch }}.zip ./.artifacts/* xpipecd-xbar.sh
+      - name: Get upload URL
+        id: get_upload_url
+        run: |
+          UPLOAD_URL=$(gh release view --json uploadUrl -q ".uploadUrl")
+          echo "::set-output name=upload_url::$UPLOAD_URL"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload ZIP Archive for ${{ matrix.os-arch.os }}/${{ matrix.os-arch.arch }}
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_upload_url.outputs.upload_url }}
+          asset_path: ./xpipecd-xbar-${{ github.sha }}-${{ matrix.os-arch.os }}-${{ matrix.os-arch.arch }}.zip
+          asset_name: xpipecd-xbar-${{ github.sha }}-${{ matrix.os-arch.os }}-${{ matrix.os-arch.arch }}.zip
+          asset_content_type: application/zip

--- a/release/RELEASE
+++ b/release/RELEASE
@@ -1,0 +1,9 @@
+tag: v0.1.0
+prerelease: false
+
+commitCategories:
+  - title: "General Updates"
+
+releaseNoteGenerator:
+  showCommitter: true
+  useReleaseNoteBlock: true


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow and a release configuration file. The most important changes include the creation of a new workflow that triggers on push events to the main branch and the addition of a release configuration file that specifies the tag, pre-release status, commit categories, and release note generator options.

GitHub Actions Workflow:

* [`.github/workflows/gh-release.yaml`](diffhunk://#diff-4d00dff56fb017e6d5bf1ff17d4c501f13b89322dd36e6cd7fd600e14152df1aR1-R53): Added a new GitHub Actions workflow that triggers on push events to the main branch or when a `workflow_dispatch` event occurs. This workflow includes two jobs: `gh-release` and `upload-artifacts`. The `gh-release` job uses the `actions/checkout@v4` and `pipe-cd/actions-gh-release@v2.6.0` actions to create a GitHub release. The `upload-artifacts` job builds the CLI for different OS and architecture combinations, creates a ZIP archive, and uploads it to the GitHub release.

Release Configuration:

* [`release/RELEASE`](diffhunk://#diff-4bde0e4e85e541a5b6d65cabfb7d022f5ed39458defcc79fdec8a72365ecd391R1-R9): Added a new release configuration file. This file specifies the tag (`v0.1.0`), pre-release status (`false`), commit categories (`General Updates`), and release note generator options (show committer and use release note block).