### PR TITLE
Release v0.1.1

### DIFF
--- a/release/RELEASE
+++ b/release/RELEASE
@@ -1,4 +1,4 @@
-tag: v0.1.0
+tag: v0.1.1
 prerelease: false
 
 commitCategories:


### PR DESCRIPTION
This pull request includes a minor change to the `release/RELEASE` file. The change updates the version tag from `v0.1.0` to `v0.1.1`.