### PR TITLE
Add Go setup and caching in GitHub Actions workflow

### DIFF
--- a/.github/workflows/gh-release.yaml
+++ b/.github/workflows/gh-release.yaml
@@ -39,6 +39,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
       - name: Build CLI for ${{ matrix.os-arch.os }}/${{ matrix.os-arch.arch }}
         run: make build/cli BUILD_OS=${{ matrix.os-arch.os }} BUILD_ARCH=${{ matrix.os-arch.arch }}
       - name: Create ZIP Archive for ${{ matrix.os-arch.os }}/${{ matrix.os-arch.arch }}


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow file, `.github/workflows/gh-release.yaml`. The change introduces a new step that sets up the Go environment before building the CLI. The new step uses the `actions/setup-go@v5` action, which is configured to use the Go version specified in the `go.mod` file and to cache the Go dependencies listed in the `go.sum` file. This change is intended to ensure that the build process uses a consistent Go environment and to speed up the build process by reusing previously downloaded Go dependencies.