### PR TITLE
Update ZIP Archive creation in gh-release.yaml

### DIFF
--- a/.github/workflows/gh-release.yaml
+++ b/.github/workflows/gh-release.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Build CLI for ${{ matrix.os-arch.os }}/${{ matrix.os-arch.arch }}
         run: make build/cli BUILD_OS=${{ matrix.os-arch.os }} BUILD_ARCH=${{ matrix.os-arch.arch }}
       - name: Create ZIP Archive for ${{ matrix.os-arch.os }}/${{ matrix.os-arch.arch }}
-        run: zip -r xpipecd-xbar-${{ github.sha }}-${{ matrix.os-arch.os }}-${{ matrix.os-arch.arch }}.zip ./.artifacts/* xpipecd-xbar.sh
+        run: zip -r xpipecd-xbar-${{ github.sha }}-${{ matrix.os-arch.os }}-${{ matrix.os-arch.arch }}.zip ./.artifacts/* xpipecd-xbar.sh Makefile
       - name: Get upload URL
         id: get_upload_url
         run: |

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,14 @@ setup/cli: ## Setup cli ## make setup/cli
 	ln -sf $(CURDIR)/.artifacts/xpipecd-xbar$(BIN_SUFFIX) $(HOME)/Library/Application\ Support/xbar/plugins/.artifacts/xpipecd-xbar
 	ln -sf $(CURDIR)/xpipecd-xbar.sh $(HOME)/Library/Application\ Support/xbar/plugins/xpipecd-xbar.$(t).sh
 
+.PHONY: setup/artifacts
+setup/cli: t ?= 30s
+setup/cli: ## Setup cli ## make setup/cli
+	mkdir -p $(HOME)/Library/Application\ Support/xbar/plugins
+	mkdir -p $(HOME)/Library/Application\ Support/xbar/plugins/.artifacts
+	ln -sf $(CURDIR)/.artifacts/xpipecd-xbar* $(HOME)/Library/Application\ Support/xbar/plugins/.artifacts/
+	ln -sf $(CURDIR)/xpipecd-xbar.sh $(HOME)/Library/Application\ Support/xbar/plugins/xpipecd-xbar.$(t).sh
+
 .PHONY: lint/cli
 lint/cli: ## Format and lint cli code ## make lint/cli
 lint/cli: STRICT_GO_IMPORTS_EXISTS = $(shell which strictgoimports)


### PR DESCRIPTION
This pull request primarily focuses on changes to the `Makefile` and the `.github/workflows/gh-release.yaml` file. The changes include the addition of a new `setup/cli` target in the `Makefile` and an update to the `Create ZIP Archive` step in the GitHub Actions workflow.

Here are the key changes in detail:

* [`.github/workflows/gh-release.yaml`](diffhunk://#diff-4d00dff56fb017e6d5bf1ff17d4c501f13b89322dd36e6cd7fd600e14152df1aL50-R50): In the `Create ZIP Archive` step, the `Makefile` has been added to the ZIP archive created during the build process. This change allows the `Makefile` to be included in the release assets.

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R32-R39): A new `setup/cli` target has been added. This target creates necessary directories and sets up symbolic links for the CLI tool in the user's xbar plugins directory. It will be helpful for setting up the CLI tool during development or deployment.