### PR TITLE
Release v0.1.5

### DIFF
--- a/.github/workflows/gh-release.yaml
+++ b/.github/workflows/gh-release.yaml
@@ -2,8 +2,8 @@ name: gh-release
 
 on:
   push:
-    branches:
-      - main
+    tags:
+    - 'v*'
   #   paths:
   #     - "**/RELEASE"
   # pull_request:

--- a/release/RELEASE
+++ b/release/RELEASE
@@ -1,4 +1,4 @@
-tag: v0.1.4
+tag: v0.1.5
 prerelease: false
 
 commitCategories:


### PR DESCRIPTION
This pull request primarily focuses on changes related to the GitHub release process. The changes are made in the `.github/workflows/gh-release.yaml` file and the `release/RELEASE` file. The most significant changes include shifting the trigger for the `gh-release` workflow from branch push to tag push, and updating the version tag in the `RELEASE` file.

* [`.github/workflows/gh-release.yaml`](diffhunk://#diff-4d00dff56fb017e6d5bf1ff17d4c501f13b89322dd36e6cd7fd600e14152df1aL5-R6): Changed the trigger for the `gh-release` workflow. Instead of triggering on a push to the `main` branch, it now triggers on the creation of tags that match the pattern 'v*'. This change makes the release process more controlled, as releases will only be created when a new version tag is pushed.
  
* [`release/RELEASE`](diffhunk://#diff-4bde0e4e85e541a5b6d65cabfb7d022f5ed39458defcc79fdec8a72365ecd391L1-R1): Updated the version tag from `v0.1.4` to `v0.1.5`. This change signifies the new version of the software that will be released.