### PR TITLE
Update gh-release.yaml to trigger workflow on push to main branch

### DIFF
--- a/.github/workflows/gh-release.yaml
+++ b/.github/workflows/gh-release.yaml
@@ -2,10 +2,10 @@ name: gh-release
 
 on:
   push:
-    tags:
-    - 'v*'
-  #   paths:
-  #     - "**/RELEASE"
+    branches:
+      - main
+    paths:
+      - "**/RELEASE"
   # pull_request:
   #   types:
   #     - opened


### PR DESCRIPTION
This pull request includes a significant change to the `.github/workflows/gh-release.yaml` file. The change modifies the triggering conditions for the `gh-release` GitHub Actions workflow. 

* [`.github/workflows/gh-release.yaml`](diffhunk://#diff-4d00dff56fb017e6d5bf1ff17d4c501f13b89322dd36e6cd7fd600e14152df1aL5-R8): The workflow was previously triggered on the push of any tags starting with 'v'. Now, it is triggered on pushes to the `main` branch. Additionally, the workflow is now configured to only run when there are changes to files with `RELEASE` in their path.