### PR TITLE
Update release tag to v0.1.6

### DIFF
--- a/release/RELEASE
+++ b/release/RELEASE
@@ -1,4 +1,4 @@
-tag: v0.1.5
+tag: v0.1.6
 prerelease: false
 
 commitCategories:


### PR DESCRIPTION
This pull request includes a minor version update in the `release/RELEASE` file. The version tag has been updated from `v0.1.5` to `v0.1.6`. This signifies that a new version of the software has been prepared for release.