### PR TITLE
Add GitHub App token for creating releases

### DIFF
--- a/.github/workflows/gh-release.yaml
+++ b/.github/workflows/gh-release.yaml
@@ -23,10 +23,16 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Create temporary access token by GitHub App
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: pipe-cd/actions-gh-release@v2.6.0
         with:
           release_file: "**/RELEASE"
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
   upload-artifacts:
     needs: gh-release
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow file `.github/workflows/gh-release.yaml`. The change involves the creation of a temporary access token by a GitHub App, which is then used as the token for the `pipe-cd/actions-gh-release@v2.6.0` action instead of the previously used `GITHUB_TOKEN`. 

This change improves the security of the workflow by using a temporary access token, which limits the permissions and duration of the token, instead of using a token with broader permissions and longer duration. This reduces the potential impact if the token is compromised.