### PR TITLE
Release v0.1.7

### DIFF
--- a/.github/workflows/gh-release.yaml
+++ b/.github/workflows/gh-release.yaml
@@ -23,10 +23,16 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Create temporary access token by GitHub App
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: pipe-cd/actions-gh-release@v2.6.0
         with:
           release_file: "**/RELEASE"
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
   upload-artifacts:
     needs: gh-release
     runs-on: ubuntu-latest

--- a/release/RELEASE
+++ b/release/RELEASE
@@ -1,4 +1,4 @@
-tag: v0.1.6
+tag: v0.1.7
 prerelease: false
 
 commitCategories:


### PR DESCRIPTION
This pull request primarily updates the GitHub Actions workflow and the version tag in the `RELEASE` file. The changes include the addition of a new step in the workflow to create a temporary access token using a GitHub App, and an update to the version tag in the `RELEASE` file.

GitHub Actions workflow update:

* [`.github/workflows/gh-release.yaml`](diffhunk://#diff-4d00dff56fb017e6d5bf1ff17d4c501f13b89322dd36e6cd7fd600e14152df1aR26-R35): A new step has been added to the workflow, named 'Create temporary access token by GitHub App'. This step uses the `actions/create-github-app-token@v1` action with the `APP_ID` and `APP_PRIVATE_KEY` secrets to create a temporary access token. This token is then used in the `pipe-cd/actions-gh-release@v2.6.0` action instead of the previously used `GITHUB_TOKEN` secret.

Version tag update:

* [`release/RELEASE`](diffhunk://#diff-4bde0e4e85e541a5b6d65cabfb7d022f5ed39458defcc79fdec8a72365ecd391L1-R1): The version tag has been updated from `v0.1.6` to `v0.1.7`.