### PR TITLE
Update release tag to v0.1.7

### DIFF
--- a/release/RELEASE
+++ b/release/RELEASE
@@ -1,4 +1,4 @@
-tag: v0.1.6
+tag: v0.1.7
 prerelease: false
 
 commitCategories:


### PR DESCRIPTION
This pull request includes a small change to the `release/RELEASE` file. The change updates the version tag from `v0.1.6` to `v0.1.7`.